### PR TITLE
Update notebook setup docs and fix Lab 2 error handling

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+DB_HOST=couchbase://couchbase
+DB_USER=Administrator
+DB_PASSWORD=Password

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A series of labs created to start using Couchbase with the Python SDK. It includ
 
 To bring up the Couchbase and the Jupyter Lab environment with the Couchbase Python SDK, run
 
-`docker-compose up`
+`docker compose up`
 
 Access the Jupyter Lab environment by clicking on the access URL in the logs as shown in the screenshot below.
 
@@ -33,7 +33,7 @@ Follow the rest of the labs sequentially.
 
 #### Configuring the Couchbase Cluster Information for Examples
 
-- The configuration is stored in an environment file, .env in this folder.
+- The configuration is stored in an environment file, `.env` in this folder. Start by copying `.env.sample` to `.env` and updating the values for your Couchbase deployment.
 
 - Note that you might have to check for hidden files to see this file on Unix environments.
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ Follow the rest of the labs sequentially.
 
 #### Configuring the Couchbase Cluster Information for Examples
 
-- The configuration is stored in an environment file, `.env` in this folder. Start by copying `.env.sample` to `.env` and updating the values for your Couchbase deployment.
+- The Docker Compose flow reads configuration from a root-level `.env` file. Start by copying `.env.sample` to `.env` and updating the values for your Couchbase deployment.
 
-- Note that you might have to check for hidden files to see this file on Unix environments.
+- If you are running the notebooks directly in Jupyter Lab from the `notebooks/` directory, also copy `.env.sample` to `notebooks/.env` so `load_dotenv()` picks up the same settings inside the notebook kernels.
 
-- This file can be used to update the connection settings.
+- Note that you might have to check for hidden files to see these files on Unix environments.
+
+- These files can be used to update the connection settings.
 
   - DB_HOST: Set to `couchbase://couchbase` by default for connecting to the Couchbase cluster in the docker environment via Docker Compose. If you are running Couchbase locally on your machine via docker or installation, you can change the connection string to `couchbase://localhost`.
   - DB_USER: Set to `Administrator` by default. If it is different for your cluster, please update the file.

--- a/notebooks/Lab_02_Key_Value_Operations.ipynb
+++ b/notebooks/Lab_02_Key_Value_Operations.ipynb
@@ -515,7 +515,7 @@
     "    result = cb_coll.lookup_in(\"customer123\", [SD.get(\"addresses.delivery.country\")])\n",
     "    country = result.content_as[str](0)\n",
     "    print(country)\n",
-    "except Exceptiona as e:\n",
+    "except Exception as e:\n",
     "    print(e)"
    ]
   },


### PR DESCRIPTION
## Summary
- add a root `.env.sample` and README guidance for copying it to `.env`
- update the Docker Compose command in the README to `docker compose up`
- fix the `Exceptiona` typo in Lab 2 so the notebook's intended error-handling path no longer aborts execution

## Verification
- `uv venv .venv-sweep --python 3.12`
- `uv pip install --python .venv-sweep/bin/python couchbase jupyterlab python-dotenv papermill ipykernel requests`
- `python pre-lab setup: ensure KV_Testing bucket, flush it, seed customer123`
- `python create FTS indexes for travel-sample-search, hotel_address, hotel_reviews`
- `papermill notebooks/Lab_01_Introduction_to_Couchbase.ipynb ... -k cblabs-sweep --cwd /home/elliot/.openclaw/state/tutorial-maintenance/repos/couchbase-jupyter-labs`
- `papermill notebooks/Lab_02_Key_Value_Operations.ipynb ... -k cblabs-sweep --cwd /home/elliot/.openclaw/state/tutorial-maintenance/repos/couchbase-jupyter-labs`
- `papermill notebooks/Lab_03_Indexing.ipynb ... -k cblabs-sweep --cwd /home/elliot/.openclaw/state/tutorial-maintenance/repos/couchbase-jupyter-labs`
- `papermill notebooks/Lab_04_N1QL_Querying.ipynb ... -k cblabs-sweep --cwd /home/elliot/.openclaw/state/tutorial-maintenance/repos/couchbase-jupyter-labs`
- `papermill notebooks/Lab_05_Full_Text_Search.ipynb ... -k cblabs-sweep --cwd /home/elliot/.openclaw/state/tutorial-maintenance/repos/couchbase-jupyter-labs`
- `uv pip install --python .venv-sweep/bin/python pip`
- `PIPAPI_PYTHON_LOCATION=/home/elliot/.openclaw/state/tutorial-maintenance/repos/couchbase-jupyter-labs/.venv-sweep/bin/python uvx --from pip-audit pip-audit`

## Evidence
- All five notebooks executed successfully with papermill after local Couchbase prep for `KV_Testing`, `customer123`, and the FTS indexes used by Lab 5.
- `pip-audit` reported `No known vulnerabilities found`.
- `tutorial-maintenance/runs/couchbase-jupyter-labs/2026-05-01T1634-notebook-feasibility/verification.md`
- `tutorial-maintenance/runs/couchbase-jupyter-labs/2026-05-01T1634-notebook-feasibility/commands.txt`
- `tutorial-maintenance/runs/couchbase-jupyter-labs/2026-05-01T1634-notebook-feasibility/executed/`

## Notes
- The repo remains a repo-level maintenance unit rather than per-notebook artifacts, so this pass verified the full notebook set.
- The Lab 2 exercise cells were left intact; the verification flow seeded `customer123` externally instead of filling in student solution cells.
- Visual screenshot capture was blocked here because no local headless browser/screenshot tool was available; executed notebooks were still saved under the run artifact directory.
