### PR TITLE
Document Python 3.10+ local runtime and Lab 5 search prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Follow the rest of the labs sequentially.
 
 ### Prerequisites
 
-- Python 3.8 or higher
+- Python 3.10 or higher (validated with Python 3.12; current `jupyterlab` and `python-dotenv` releases no longer support Python 3.8)
 
 - Install the Couchbase SDK (v4 or above), `python-dotenv`, and Jupyter Lab
 
@@ -58,6 +58,8 @@ Follow the rest of the labs sequentially.
 - Running Couchbase using Docker
 
   `docker run -d --name db -p 8091-8094:8091-8094 -p 11210:11210 couchbase`
+
+- Load the `travel-sample` bucket before starting the notebooks. Labs 1-4 require the Query and Index services, and Lab 5 also requires the Search service to be enabled and reachable on port `8094`.
 
 - Running the Labs by running Jupyter Lab from this folder
   `jupyter lab`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Follow the rest of the labs sequentially.
 
 ### Prerequisites
 
-- Python 3.10 or higher (validated with Python 3.12; current `jupyterlab` and `python-dotenv` releases no longer support Python 3.8)
+- Python 3.10 or higher
 
 - Install the Couchbase SDK (v4 or above), `python-dotenv`, and Jupyter Lab
 
@@ -59,7 +59,7 @@ Follow the rest of the labs sequentially.
 
   `docker run -d --name db -p 8091-8094:8091-8094 -p 11210:11210 couchbase`
 
-- Load the `travel-sample` bucket before starting the notebooks. Labs 1-4 require the Query and Index services, and Lab 5 also requires the Search service to be enabled and reachable on port `8094`.
+- Load the `travel-sample` bucket before starting the notebooks. Several labs use the Query and Index services, and Lab 5 requires the Search service to be enabled.
 
 - Running the Labs by running Jupyter Lab from this folder
   `jupyter lab`


### PR DESCRIPTION
## Summary
- raise the documented local Python baseline from 3.8+ to 3.10+
- clarify that the notebooks need `travel-sample`, Query/Index services for Labs 1-4, and a reachable Search service for Lab 5

## Verification
- `uv venv .venv-sweep-20260615 --python 3.12`
- `uv pip install --python .venv-sweep-20260615/bin/python couchbase jupyterlab python-dotenv papermill ipykernel requests nbconvert`
- `PIPAPI_PYTHON_LOCATION=/home/elliot/.openclaw/state/tutorial-maintenance/repos/couchbase-jupyter-labs/.venv-sweep-20260615/bin/python uvx --from pip-audit pip-audit`
- papermill passed for Labs 1-4 and reproduced the existing Lab 5 Search-service blocker

## Evidence
- Passed notebooks: Labs 1-4 executed successfully under papermill from a fresh Python 3.12 environment.
- Blocked notebook: Lab 5 still fails because the local cluster's Search service is not reachable on `:8094`, so `cluster.search_query(...)` raises `ServiceUnavailableException`.
- `tutorial-maintenance/runs/couchbase-jupyter-labs/2026-06-15T1852-notebook-pass/verification.md`
- `tutorial-maintenance/runs/couchbase-jupyter-labs/2026-06-15T1852-notebook-pass/lab-04-querying.png`
- `tutorial-maintenance/runs/couchbase-jupyter-labs/2026-06-15T1852-notebook-pass/lab-04-querying.webm`

## Notes
- Executed notebooks: `Lab_01_Introduction_to_Couchbase`, `Lab_02_Key_Value_Operations`, `Lab_03_Indexing`, `Lab_04_N1QL_Querying`
- Skipped/blocked notebook: `Lab_05_Full_Text_Search` due to missing reachable Search service on this machine's local Couchbase node
- Full run artifacts live under `tutorial-maintenance/runs/couchbase-jupyter-labs/2026-06-15T1852-notebook-pass/`

## Media evidence
- Auto-attached reviewer-facing media from the local verification artifacts captured during this run.
- This keeps the main PR body self-contained instead of relying on a follow-up comment for visual proof.

![Lab 04 Querying](https://res.cloudinary.com/dhwqj0ps2/image/upload/v1781575974/pr-evidence/couchbase-examples/couchbase-jupyter-labs/pr-5/lab-04-querying.png)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/couchbase-jupyter-labs/2026-06-15T1852-notebook-pass/lab-04-querying.png`

</details>

[Lab 04 Querying](https://res.cloudinary.com/dhwqj0ps2/video/upload/v1781575983/pr-evidence/couchbase-examples/couchbase-jupyter-labs/pr-5/lab-04-querying.webm)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/couchbase-jupyter-labs/2026-06-15T1852-notebook-pass/lab-04-querying.webm`

</details>
